### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The storage depends on a redis client instance.
 
 ```javascript
 var redis = require('redis')
-var RedisStorage = require('botbuilder-redis-storage')
+var RedisStorage = require('botbuilder-redis-storage').RedisStorage
 var builder = require('botbuilder')
 
 // Initialize redis client


### PR DESCRIPTION
I've changed import of RedisStorage class.
After last update, it says:
```
TypeError: RedisStorage is not a function
```
So, I've logged `RedisStorage` to console, and saw, that it's an object:
```
{ RedisStorage: [Function: RedisStorage] }
```

I've changed my code from
```
const RedisStorage = require('botbuilder-redis-storage');
```
to
```
const RedisStorage = require('botbuilder-redis-storage').RedisStorage;
```
And it worked.